### PR TITLE
Support hitting https sites.

### DIFF
--- a/lib/ab.js
+++ b/lib/ab.js
@@ -17,9 +17,10 @@ var user_option = url.parse(uri);
 if(!user_option.hostname || !user_option.path) {
   return console.log("Not validate [URL]".red);
 }
-debugger;
 
-if (user_option.protocol === 'https:') {
+var useHTTPS = (user_option.protocol === 'https:');
+
+if (useHTTPS) {
   httpLib = require('https');
 }
 
@@ -39,6 +40,10 @@ var bench_intv = function() {
       path: user_option.path + '?i='+stats.req_num,
       method: 'GET'
     };
+
+    if (useHTTPS) {
+      options.rejectUnauthorized = false;
+    }
 
     var callback = function(res) {
       if(res.statusCode === 200) {


### PR DESCRIPTION
This PR contains two changes so that `node-ab` can be used to hit sites that use https:
1. Use the `https` module instead of the `http` module if the URL passed in uses the https: protocol.
2. Accept self-signed certificates from the site.
